### PR TITLE
Added different speeds to each of the spaceships.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "afloop": "^1.0.2",
-    "keyb": "^1.0.4",
+    "keyb": "^1.1.0",
     "pixi.js": "^4.0.0-rc3"
   },
   "devDependencies": {

--- a/source/index.js
+++ b/source/index.js
@@ -59,7 +59,40 @@ var BLUE_TEXTURE = Pixi.Texture.fromImage(require("images/blue-starship.png"))
 var GREEN_TEXTURE = Pixi.Texture.fromImage(require("images/green-starship.png"))
 var YELLOW_TEXTURE = Pixi.Texture.fromImage(require("images/yellow-starship.png"))
 
-var spaceshipTextures = [RED_TEXTURE, BLUE_TEXTURE, GREEN_TEXTURE, YELLOW_TEXTURE]
+var SPACESHIPS = [
+    {
+        speed: 0.05,
+        texture: RED_TEXTURE,
+        onShootSpeed: 100,
+        onShoot: function() {
+            console.log("BANG")
+        }
+    },
+    {
+        speed: 0.1,
+        texture: BLUE_TEXTURE,
+        onShootSpeed: 200,
+        onShoot: function() {
+            console.log("BOOM")
+        }
+    },
+    {
+        speed: 0.025,
+        texture: GREEN_TEXTURE,
+        onShootSpeed: 50,
+        onShoot: function() {
+            console.log("BZAP")
+        }
+    },
+    {
+        speed: 0.1,
+        texture: YELLOW_TEXTURE,
+        onShootSpeed: 75,
+        onShoot: function() {
+            console.log("BOOF")
+        }
+    }
+]
 
 class Hero extends Pixi.Sprite {
     // Because we inheriting from sprite, we're
@@ -75,8 +108,10 @@ class Hero extends Pixi.Sprite {
         this.anchor.x = 0.5
         this.anchor.y = 0.5
 
-        this.speed = 0.1
-        this.textureIndex = 0
+        this.spaceshipIndex = 0
+        this.setSpaceship(SPACESHIPS[this.spaceshipIndex])
+
+        this.onShootTimer = 0
     }
     // We'll add a method to run
     // each frame to update the sprite.
@@ -93,14 +128,27 @@ class Hero extends Pixi.Sprite {
             this.position.x += this.speed * delta
         }
 
-        // This will change the sprite's texture
-        if(Keyb.isJustDown("<shift>")) {
-            this.changeTexture()
+        // This will change the sprite's texture, speed, and more.
+        if(Keyb.isJustDown("<shift>", delta)) {
+            // Use some modulo logic to toggle to the next spaceship.
+            this.spaceshipIndex = (this.spaceshipIndex + 1) % SPACESHIPS.length
+            var spaceship = SPACESHIPS[this.spaceshipIndex]
+
+            // Set the spaceship.
+            this.setSpaceship(spaceship)
+        }
+
+        this.onShootTimer += delta
+        if(this.onShootTimer > this.onShootSpeed) {
+            this.onShootTimer = 0
+            this.onShoot()
         }
     }
-    changeTexture() {
-        this.textureIndex = (this.textureIndex + 1) % spaceshipTextures.length
-        this.texture = spaceshipTextures[this.textureIndex]
+    setSpaceship(spaceship) {
+        this.texture = spaceship.texture
+        this.speed = spaceship.speed
+        this.onShoot = spaceship.onShoot
+        this.onShootSpeed = spaceship.onShootSpeed
     }
 }
 


### PR DESCRIPTION
## Description
- Imported a new version of Keyb to fix the "first-keypress-being-ignored" issue.
- Expanded `spaceshipTextures` into `spaceships`, which is an array of not only spaceship textures, but spaceship speeds. :]
## Playable Build

https://ehgoodenough.github.io/ld36/pr3
## Screenshots

![pr3](https://cloud.githubusercontent.com/assets/1202938/17917540/581bfe56-6972-11e6-94fa-2827df7c95c8.gif)
Each of the different spaceships have a different speed. Some move fast, some move slow.

![pr3a](https://cloud.githubusercontent.com/assets/1202938/17917539/568d397e-6972-11e6-8fb9-14764b44700f.gif)
Each of the different spaceships have a different shooting speed. See how the `console.log`s are all printing at different speeds? Imagine each of those were a bullet. :p We haven't implemented the different weapons, but I imagine each of them would have a different type of gun (shotgun, machine gun, spread/spray?).
